### PR TITLE
fixed: []uint8 is not io.Reader: missing method Read

### DIFF
--- a/peer/http/respond_msg.go
+++ b/peer/http/respond_msg.go
@@ -3,11 +3,10 @@ package http
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/davyxu/cellnet"
 	"github.com/davyxu/cellnet/codec"
-	"io"
-	"io/ioutil"
-	"net/http"
 )
 
 type MessageRespond struct {
@@ -49,13 +48,7 @@ func (self *MessageRespond) WriteRespond(ses *httpSession) error {
 
 	ses.resp.Header().Set("Content-Type", httpCodec.MimeType()+";charset=UTF-8")
 	ses.resp.WriteHeader(http.StatusOK)
-
-	bodyData, err := ioutil.ReadAll(data.(io.Reader))
-	if err != nil {
-		return err
-	}
-
-	ses.resp.Write(bodyData)
+	ses.resp.Write(data)
 
 	return nil
 }

--- a/peer/http/respond_msg.go
+++ b/peer/http/respond_msg.go
@@ -48,7 +48,7 @@ func (self *MessageRespond) WriteRespond(ses *httpSession) error {
 
 	ses.resp.Header().Set("Content-Type", httpCodec.MimeType()+";charset=UTF-8")
 	ses.resp.WriteHeader(http.StatusOK)
-	ses.resp.Write(data)
+	ses.resp.Write(data.([]byte))
 
 	return nil
 }


### PR DESCRIPTION
当使用 json 作为返回结果时， data 不是 ioReader https://golang.org/pkg/encoding/json/#MarshalIndent.   而是 []byte, 所以不需要转换.

````
2018/10/27 21:49:48 http: multiple response.WriteHeader calls
panic: interface conversion: []uint8 is not io.Reader: missing method Read

goroutine 19 [running]:
github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/peer/http.(*MessageRespond).WriteRespond(0xc0003a6000, 0xc00016a000, 0xc0003a6000, 0x7f7b543698c0)
        /go/src/github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/peer/http/respond_msg.go:53 +0x46e
github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/peer/http.(*httpSession).Send(0xc00016a000, 0x7bb440, 0xc0003a6000)
        /go/src/github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/peer/http/session.go:72 +0xa6
github.com/jamlee/bee-server/server.RunControlEndpoint.func1(0x895ee0, 0xc00000b720)
        /go/src/github.com/jamlee/bee-server/server/server.go:28 +0x184
github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/proc.NewQueuedEventCallback.func1.1()
        /go/src/github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/proc/procbundle.go:27 +0x37
github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet.(*eventQueue).protectedCall(0xc00014e0e0, 0xc00000b740)
        /go/src/github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/queue.go:64 +0x37
github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet.(*eventQueue).StartLoop.func1(0xc00014e0e0)
        /go/src/github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/queue.go:84 +0x169
created by github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet.(*eventQueue).StartLoop
        /go/src/github.com/jamlee/bee-server/vendor/github.com/davyxu/cellnet/queue.go:72 +0x5c
````